### PR TITLE
Fix build trigger

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -2,7 +2,7 @@ name: Build on release
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   build:


### PR DESCRIPTION
"Published" event only fires when a draft gets published

**What does this change do?**

**What does this mean for future development?**
Do we need to change how we make other things now?